### PR TITLE
Fix bug in handling the one-shot event

### DIFF
--- a/src/epoll.c
+++ b/src/epoll.c
@@ -28,11 +28,11 @@ static int check_event_status(lua_State *L, poll_event_t *ev)
     int rc = POLL_OK;
 
     if (ev->reg_evt.events & EV_ONESHOT) {
-        // oneshot event must be removed from the event set table and manually
-        // disable event
-        poll_evset_del(L, ev);
-        ev->enabled = 0;
-        rc          = EV_ONESHOT;
+        // oneshot event should be disabled
+        if (poll_unwatch_event(L, ev) == POLL_ERROR) {
+            return POLL_ERROR;
+        }
+        rc = EV_ONESHOT;
     } else if (ev->occ_evt.events & (EV_EOF | EV_ERROR)) {
         // event should be disabled when error occurred or EV_EOF is set
         if (poll_unwatch_event(L, ev) == POLL_ERROR) {

--- a/test/epoll_test.lua
+++ b/test/epoll_test.lua
@@ -213,6 +213,13 @@ function testcase.oneshot_event_will_be_disabled_in_consume()
     -- test that onshot-event will be deleted after event occurred
     assert.equal(#ep, 0)
     assert.equal(assert(ep:wait(10)), 0)
+
+    -- test that fd will be deleted from epoll after event occurred
+    ev = ep:new_event()
+    ev:as_oneshot()
+    assert(ev:as_read(Reader:fd(), {
+        'context',
+    }))
 end
 
 function testcase.edge_triggered_event_will_not_repeat()


### PR DESCRIPTION
one-shot events must be manually removed from epoll.