### PR TITLE
Add trigger event type using Linux eventfd in counter and semaphore modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ print('n:', n)
 local occurred, udata, disabled, eof, err, errno = ep:consume()
 if err then
     print('error:', err, errno)
-elseif ocurred then
-    print('event occurred:', ocurred, udata)
+elseif occurred then
+    print('event occurred:', occurred, udata)
 end
 ```
 
@@ -156,6 +156,7 @@ end
 - Write event: it watches the file descriptor until it becomes writable.
 - Signal event: it watches the signal until it becomes occurred.
 - Timer event: it watches the timer until it becomes expired.
+- Trigger event: it fires a user-controlled wakeup on demand.
 
 
 ## ok, err, errno = ev:renew( [ep] )
@@ -182,16 +183,17 @@ return `true` if the event trigger is level trigger.
 - `ok:boolean`: `true` if the event trigger is level trigger.
 
 
-## ok = ev:as_level()
+## ev, err, errno = ev:as_level()
 
 change the event trigger to level trigger.
 
 **NOTE:** the level trigger is a trigger that is activated while the state of the target is active.
 
-
 **Returns**
 
-- `ok:boolean`: `true` on success.
+- `ev:epoll.event?`: `epoll.event` instance on success, or `nil` if error occurred.
+- `err:string`: error string.
+- `errno:number`: error number.
 
 
 ## ok = ev:is_edge()
@@ -203,7 +205,7 @@ return `true` if the event trigger is edge trigger.
 - `ok:boolean`: `true` if the event trigger is edge trigger.
 
 
-## ok = ev:as_edge()
+## ev, err, errno = ev:as_edge()
 
 change the event trigger to edge trigger.
 
@@ -211,7 +213,9 @@ change the event trigger to edge trigger.
 
 **Returns**
 
-- `ok:boolean`: `true` on success.
+- `ev:epoll.event?`: `epoll.event` instance on success, or `nil` if error occurred.
+- `err:string`: error string.
+- `errno:number`: error number.
 
 
 ## ok = ev:is_oneshot()
@@ -223,7 +227,7 @@ return `true` if the event type is one-shot event.
 - `ok:boolean`: `true` if the event type is one-shot event.
 
 
-## ok = ev:as_oneshot()
+## ev, err, errno = ev:as_oneshot()
 
 change the event type to one-shot event.
 
@@ -231,7 +235,9 @@ change the event type to one-shot event.
 
 **Returns**
 
-- `ok:boolean`: `true` on success.
+- `ev:epoll.event?`: `epoll.event` instance on success, or `nil` if error occurred.
+- `err:string`: error string.
+- `errno:number`: error number.
 
 
 ## ev, err, errno = ev:as_read( fd [, udata] )
@@ -405,7 +411,7 @@ local ep = assert(epoll.new())
 
 -- register a new event for the timer
 local ev = assert(ep:new_event())
-assert(ev:as_timer(123, 150, 'timer expired after 150 milliseconds'))
+assert(ev:as_timer(123, 0.150, 'timer expired after 150 milliseconds'))
 
 -- wait until the timer is expired
 local n, err, errno = ep:wait()
@@ -428,9 +434,73 @@ end
 ```
 
 
+## ev, err, errno = ev:as_trigger( [semaphore [, udata]] )
+
+register a trigger event that fires on demand by calling `ev:trigger()`.
+
+this method changes the meta-table of the `ev` to `epoll.trigger`.
+
+**Parameters**
+
+- `semaphore:boolean`: if `true`, use semaphore mode where each `trigger()` call fires one independent wake-up. if `false` (default), counter mode coalesces multiple `trigger()` calls into a single wake-up.
+- `udata:any`: user data.
+
+**Returns**
+
+- `ev:epoll.trigger?`: `epoll.trigger` instance, or `nil` if error occurred.
+- `err:string`: error string.
+- `errno:number`: error number.
+
+**Example**
+
+```lua
+local epoll = require('epoll')
+local ep = assert(epoll.new())
+
+-- register a trigger event
+local ev = assert(ep:new_event())
+assert(ev:as_trigger(false, 'trigger context'))
+
+-- fire the trigger from anywhere (e.g. another coroutine)
+assert(ev:trigger())
+
+-- wait for the event
+local n, err, errno = ep:wait(1.0)
+if err then
+    print(err, errno)
+    return
+end
+print('n:', n)
+
+-- consume the event
+while true do
+    local occurred, udata, disabled, eof, err, errno = ep:consume()
+    if err then
+        print('error:', err, errno)
+    elseif not occurred then
+        break
+    end
+    print('event occurred:', occurred, udata)
+end
+```
+
+
+## ok, err, errno = ev:trigger()
+
+fire the trigger event to wake up a waiting `ep:wait()` call.
+
+**NOTE:** returns an error if the event is not currently watched (disabled).
+
+**Returns**
+
+- `ok:boolean`: `true` on success.
+- `err:string`: error string.
+- `errno:number`: error number.
+
+
 ## Common Methods
 
-the following methods are common methods of the `epoll.read`, `epoll.write`, `epoll.signal` and `epoll.timer` instances.
+the following methods are common methods of the `epoll.read`, `epoll.write`, `epoll.signal`, `epoll.timer` and `epoll.trigger` instances.
 
 ## t = ev:type()
 
@@ -444,6 +514,7 @@ return the event type.
   - `write`: type of the `epoll.write` instance.
   - `signal`: type of the `epoll.signal` instance.
   - `timer`: type of the `epoll.timer` instance.
+  - `trigger`: type of the `epoll.trigger` instance.
 
 
 ## ok, err, errno = ev:renew( [ep] )
@@ -482,6 +553,7 @@ watch the event.
 - `epoll.write`: file descriptor used as the identifier.
 - `epoll.signal`: signal number used as the identifier.
 - `epoll.timer`: timer identifier used as the identifier.
+- `epoll.trigger`: eventfd file descriptor used as the identifier.
 
 **Returns**
 
@@ -530,7 +602,7 @@ return `true` if the event trigger is level trigger.
 - `ok:boolean`: `true` if the event trigger is level trigger.
 
 
-## ok, err, errno = ev:as_level()
+## ev, err, errno = ev:as_level()
 
 change the event trigger to level trigger.
 
@@ -538,7 +610,7 @@ change the event trigger to level trigger.
 
 **Returns**
 
-- `ok:boolean`: `true` on success.
+- `ev:epoll.event?`: the event instance on success, or `nil` if error occurred.
 - `err:string`: error string.
 - `errno:number`: error number.
 
@@ -552,7 +624,7 @@ return `true` if the event trigger is edge trigger.
 - `ok:boolean`: `true` if the event trigger is edge trigger.
 
 
-## ok, err, errno = ev:as_edge()
+## ev, err, errno = ev:as_edge()
 
 change the event trigger to edge trigger.
 
@@ -560,7 +632,7 @@ change the event trigger to edge trigger.
 
 **Returns**
 
-- `ok:boolean`: `true` on success.
+- `ev:epoll.event?`: the event instance on success, or `nil` if error occurred.
 - `err:string`: error string.
 - `errno:number`: error number.
 
@@ -574,7 +646,7 @@ return `true` if the event type is one-shot event.
 - `ok:boolean`: `true` if the event type is one-shot event.
 
 
-## ok, err, errno = ev:as_oneshot()
+## ev, err, errno = ev:as_oneshot()
 
 change the event type to one-shot event.
 
@@ -582,7 +654,7 @@ change the event type to one-shot event.
 
 **Returns**
 
-- `ok:boolean`: `true` on success.
+- `ev:epoll.event?`: the event instance on success, or `nil` if error occurred.
 - `err:string`: error string.
 - `errno:number`: error number.
 
@@ -611,8 +683,6 @@ if the `udata` is specified then it set the user data of the event and return th
 
 get the information of the specified event.
 
-**NOTE:** if the `EV_ERROR` flag is present in the flags, then the `data` treated as the `errno`.
-
 **Parameters**
 
 - `event:string`: event name as follows.
@@ -626,4 +696,5 @@ get the information of the specified event.
   - `udata:any`: user data of the event.
   - `edge:boolean`: `true` if the event trigger is edge trigger.
   - `oneshot:boolean`: `true` if the event type is one-shot event.
+  - `eof:boolean`: `true` if the event was closed or errored (`EPOLLHUP`, `EPOLLRDHUP` or `EPOLLERR`). only present when set.
 

--- a/src/common.c
+++ b/src/common.c
@@ -36,7 +36,8 @@ static inline void event_closefd(poll_event_t *ev)
 
     case EVFILT_SIGNAL:
     case EVFILT_TIMER:
-        // close signalfd or timerfd
+    case EVFILT_TRIGGER:
+        // close signalfd, timerfd, or eventfd
         close(ev->reg_evt.data.fd);
         ev->reg_evt.data.fd = -1;
         break;
@@ -146,6 +147,9 @@ static void evset_setflag(lua_State *L, poll_event_t *ev)
     case EVFILT_TIMER:
         ref_evset = ev->p->ref_evset_timer;
         break;
+    case EVFILT_TRIGGER:
+        ref_evset = ev->p->ref_evset_trigger;
+        break;
     }
 
     pushref(L, ref_evset);
@@ -170,6 +174,9 @@ static void evset_unsetflag(lua_State *L, poll_event_t *ev)
         break;
     case EVFILT_TIMER:
         ref_evset = ev->p->ref_evset_timer;
+        break;
+    case EVFILT_TRIGGER:
+        ref_evset = ev->p->ref_evset_trigger;
         break;
     }
 

--- a/src/epoll.c
+++ b/src/epoll.c
@@ -53,7 +53,9 @@ static int check_event_status(lua_State *L, poll_event_t *ev)
     switch (ev->filter) {
     case EVFILT_SIGNAL:
         size = sizeof(struct signalfd_siginfo);
+        /* fall through */
     case EVFILT_TIMER:
+    case EVFILT_TRIGGER:
         if (read(ev->reg_evt.data.fd, (void *)&data, size) == -1) {
             return POLL_ERROR;
         }
@@ -283,6 +285,7 @@ static int gc_lua(lua_State *L)
     unref(L, p->ref_evset_write);
     unref(L, p->ref_evset_signal);
     unref(L, p->ref_evset_timer);
+    unref(L, p->ref_evset_trigger);
     unref(L, p->ref_evlist);
 
     return 0;
@@ -294,13 +297,14 @@ static int new_lua(lua_State *L)
 
     *p = (poll_t){
         // create poll descriptor
-        .fd               = poll_open(),
-        .ref_evset        = LUA_NOREF,
-        .ref_evset_read   = LUA_NOREF,
-        .ref_evset_write  = LUA_NOREF,
-        .ref_evset_signal = LUA_NOREF,
-        .ref_evset_timer  = LUA_NOREF,
-        .ref_evlist       = LUA_NOREF,
+        .fd                = poll_open(),
+        .ref_evset         = LUA_NOREF,
+        .ref_evset_read    = LUA_NOREF,
+        .ref_evset_write   = LUA_NOREF,
+        .ref_evset_signal  = LUA_NOREF,
+        .ref_evset_timer   = LUA_NOREF,
+        .ref_evset_trigger = LUA_NOREF,
+        .ref_evlist        = LUA_NOREF,
     };
 
     if (p->fd == -1) {
@@ -324,6 +328,8 @@ static int new_lua(lua_State *L)
     p->ref_evset_signal = getref(L);
     lua_newtable(L);
     p->ref_evset_timer = getref(L);
+    lua_newtable(L);
+    p->ref_evset_trigger = getref(L);
 
     return 1;
 }
@@ -355,6 +361,7 @@ LUALIB_API int luaopen_epoll(lua_State *L)
     libopen_poll_write(L);
     libopen_poll_signal(L);
     libopen_poll_timer(L);
+    libopen_poll_trigger(L);
 
     // create metatable
     luaL_newmetatable(L, POLL_MT);

--- a/src/event.c
+++ b/src/event.c
@@ -83,19 +83,20 @@ void libopen_poll_event(lua_State *L)
         {NULL,         NULL        }
     };
     struct luaL_Reg method[] = {
-        {"type",       type_lua       },
-        {"renew",      renew_lua      },
-        {"is_level",   is_level_lua   },
-        {"as_level",   as_level_lua   },
-        {"is_edge",    is_edge_lua    },
-        {"as_edge",    as_edge_lua    },
-        {"is_oneshot", is_oneshot_lua },
-        {"as_oneshot", as_oneshot_lua },
-        {"as_read",    poll_raed_new  },
-        {"as_write",   poll_write_new },
-        {"as_signal",  poll_signal_new},
-        {"as_timer",   poll_timer_new },
-        {NULL,         NULL           }
+        {"type",       type_lua        },
+        {"renew",      renew_lua       },
+        {"is_level",   is_level_lua    },
+        {"as_level",   as_level_lua    },
+        {"is_edge",    is_edge_lua     },
+        {"as_edge",    as_edge_lua     },
+        {"is_oneshot", is_oneshot_lua  },
+        {"as_oneshot", as_oneshot_lua  },
+        {"as_read",    poll_raed_new   },
+        {"as_write",   poll_write_new  },
+        {"as_signal",  poll_signal_new },
+        {"as_timer",   poll_timer_new  },
+        {"as_trigger", poll_trigger_new},
+        {NULL,         NULL            }
     };
 
     // create metatable

--- a/src/lua_epoll.h
+++ b/src/lua_epoll.h
@@ -27,6 +27,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <signal.h>
+#include <stdint.h>
 #include <string.h>
 #include <sys/epoll.h>
 #include <unistd.h>
@@ -61,10 +62,11 @@ static inline void pushref(lua_State *L, int ref)
 # define poll_open() epoll_create(1)
 #endif
 
-#define EVFILT_READ   0x1
-#define EVFILT_WRITE  0x2
-#define EVFILT_SIGNAL 0x3
-#define EVFILT_TIMER  0x4
+#define EVFILT_READ    0x1
+#define EVFILT_WRITE   0x2
+#define EVFILT_SIGNAL  0x3
+#define EVFILT_TIMER   0x4
+#define EVFILT_TRIGGER 0x5
 
 #define EV_CLEAR   EPOLLET
 #define EV_ONESHOT EPOLLONESHOT
@@ -84,6 +86,7 @@ typedef struct {
     int ref_evset_write;
     int ref_evset_signal;
     int ref_evset_timer;
+    int ref_evset_trigger;
     int ref_evlist;
     int nreg;
     int nevt;
@@ -103,23 +106,26 @@ typedef struct {
     event_t occ_evt; // occurred event
 } poll_event_t;
 
-#define POLL_MT        "epoll"
-#define POLL_EVENT_MT  "epoll.event"
-#define POLL_READ_MT   "epoll.read"
-#define POLL_WRITE_MT  "epoll.write"
-#define POLL_SIGNAL_MT "epoll.signal"
-#define POLL_TIMER_MT  "epoll.timer"
+#define POLL_MT         "epoll"
+#define POLL_EVENT_MT   "epoll.event"
+#define POLL_READ_MT    "epoll.read"
+#define POLL_WRITE_MT   "epoll.write"
+#define POLL_SIGNAL_MT  "epoll.signal"
+#define POLL_TIMER_MT   "epoll.timer"
+#define POLL_TRIGGER_MT "epoll.trigger"
 
 void libopen_poll_event(lua_State *L);
 void libopen_poll_read(lua_State *L);
 void libopen_poll_write(lua_State *L);
 void libopen_poll_signal(lua_State *L);
 void libopen_poll_timer(lua_State *L);
+void libopen_poll_trigger(lua_State *L);
 
 int poll_raed_new(lua_State *L);
 int poll_write_new(lua_State *L);
 int poll_signal_new(lua_State *L);
 int poll_timer_new(lua_State *L);
+int poll_trigger_new(lua_State *L);
 
 int poll_event_gc_lua(lua_State *L);
 int poll_event_tostring_lua(lua_State *L, const char *tname);

--- a/src/trigger.c
+++ b/src/trigger.c
@@ -1,0 +1,232 @@
+/**
+ *  Copyright (C) 2026 Masatoshi Fukunaga
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a
+ *  copy of this software and associated documentation files (the "Software"),
+ *  to deal in the Software without restriction, including without limitation
+ *  the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ *  and/or sell copies of the Software, and to permit persons to whom the
+ *  Software is furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ *  THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ *  DEALINGS IN THE SOFTWARE.
+ */
+
+#include "lua_epoll.h"
+#include <sys/eventfd.h>
+
+#define MODULE_MT POLL_TRIGGER_MT
+
+int poll_trigger_new(lua_State *L)
+{
+    poll_event_t *ev = luaL_checkudata(L, 1, POLL_EVENT_MT);
+    int semaphore    = lua_toboolean(L, 2);
+    int flags = EFD_CLOEXEC | EFD_NONBLOCK | (semaphore ? EFD_SEMAPHORE : 0);
+
+    // keep udata reference (arg 3)
+    if (!lua_isnoneornil(L, 3)) {
+        ev->ref_udata = getrefat(L, 3);
+    }
+
+    int efd = eventfd(0, flags);
+    if (efd == -1) {
+        lua_pushnil(L);
+        lua_pushstring(L, strerror(errno));
+        lua_pushinteger(L, errno);
+        return 3;
+    }
+
+    ev->ident           = efd;
+    ev->filter          = EVFILT_TRIGGER;
+    ev->reg_evt.events  = EPOLLIN;
+    ev->reg_evt.data.fd = efd;
+    if (poll_watch_event(L, ev, 1) != POLL_OK) {
+        int err = errno;
+        close(efd);
+        ev->ident           = 0;
+        ev->filter          = 0;
+        ev->reg_evt.events  = 0;
+        ev->reg_evt.data.fd = 0;
+        errno               = err;
+        lua_pushnil(L);
+        lua_pushstring(L, strerror(errno));
+        lua_pushinteger(L, errno);
+        return 3;
+    }
+
+    lua_settop(L, 1);
+    luaL_getmetatable(L, MODULE_MT);
+    lua_setmetatable(L, -2);
+    return 1;
+}
+
+static int trigger_lua(lua_State *L)
+{
+    poll_event_t *ev = luaL_checkudata(L, 1, MODULE_MT);
+    uint64_t val     = 1;
+
+    if (!ev->enabled) {
+        errno = EINPROGRESS;
+        lua_pushboolean(L, 0);
+        lua_pushstring(L, strerror(errno));
+        lua_pushinteger(L, errno);
+        return 3;
+    }
+
+    while (write(ev->reg_evt.data.fd, &val, sizeof(val)) == -1) {
+        if (errno == EINTR) {
+            continue;
+        }
+        lua_pushboolean(L, 0);
+        lua_pushstring(L, strerror(errno));
+        lua_pushinteger(L, errno);
+        return 3;
+    }
+
+    lua_pushboolean(L, 1);
+    return 1;
+}
+
+static int getinfo_lua(lua_State *L)
+{
+    return poll_event_getinfo_lua(L, MODULE_MT);
+}
+
+static int udata_lua(lua_State *L)
+{
+    return poll_event_udata_lua(L, MODULE_MT);
+}
+
+static int ident_lua(lua_State *L)
+{
+    return poll_event_ident_lua(L, MODULE_MT);
+}
+
+static int as_oneshot_lua(lua_State *L)
+{
+    return poll_event_as_oneshot_lua(L, MODULE_MT);
+}
+
+static int is_oneshot_lua(lua_State *L)
+{
+    return poll_event_is_oneshot_lua(L, MODULE_MT);
+}
+
+static int as_edge_lua(lua_State *L)
+{
+    return poll_event_as_edge_lua(L, MODULE_MT);
+}
+
+static int is_edge_lua(lua_State *L)
+{
+    return poll_event_is_edge_lua(L, MODULE_MT);
+}
+
+static int as_level_lua(lua_State *L)
+{
+    return poll_event_as_level_lua(L, MODULE_MT);
+}
+
+static int is_level_lua(lua_State *L)
+{
+    return poll_event_is_level_lua(L, MODULE_MT);
+}
+
+static int is_eof_lua(lua_State *L)
+{
+    return poll_event_is_eof_lua(L, MODULE_MT);
+}
+
+static int is_enabled_lua(lua_State *L)
+{
+    return poll_event_is_enabled_lua(L, MODULE_MT);
+}
+
+static int unwatch_lua(lua_State *L)
+{
+    return poll_event_unwatch_lua(L, MODULE_MT);
+}
+
+static int watch_lua(lua_State *L)
+{
+    return poll_event_watch_lua(L, MODULE_MT);
+}
+
+static int revert_lua(lua_State *L)
+{
+    return poll_event_revert_lua(L, MODULE_MT);
+}
+
+static int renew_lua(lua_State *L)
+{
+    return poll_event_renew_lua(L, MODULE_MT);
+}
+
+static int type_lua(lua_State *L)
+{
+    lua_pushliteral(L, "trigger");
+    return 1;
+}
+
+static int tostring_lua(lua_State *L)
+{
+    return poll_event_tostring_lua(L, MODULE_MT);
+}
+
+static int gc_lua(lua_State *L)
+{
+    return poll_event_gc_lua(L);
+}
+
+void libopen_poll_trigger(lua_State *L)
+{
+    struct luaL_Reg mmethod[] = {
+        {"__gc",       gc_lua      },
+        {"__tostring", tostring_lua},
+        {NULL,         NULL        }
+    };
+    struct luaL_Reg method[] = {
+        {"type",       type_lua      },
+        {"renew",      renew_lua     },
+        {"revert",     revert_lua    },
+        {"watch",      watch_lua     },
+        {"unwatch",    unwatch_lua   },
+        {"trigger",    trigger_lua   },
+        {"is_enabled", is_enabled_lua},
+        {"is_eof",     is_eof_lua    },
+        {"is_level",   is_level_lua  },
+        {"as_level",   as_level_lua  },
+        {"is_edge",    is_edge_lua   },
+        {"as_edge",    as_edge_lua   },
+        {"is_oneshot", is_oneshot_lua},
+        {"as_oneshot", as_oneshot_lua},
+        {"ident",      ident_lua     },
+        {"udata",      udata_lua     },
+        {"getinfo",    getinfo_lua   },
+        {NULL,         NULL          }
+    };
+
+    // create metatable
+    luaL_newmetatable(L, MODULE_MT);
+    // metamethods
+    for (struct luaL_Reg *ptr = mmethod; ptr->name; ptr++) {
+        lua_pushcfunction(L, ptr->func);
+        lua_setfield(L, -2, ptr->name);
+    }
+    // methods
+    lua_newtable(L);
+    for (struct luaL_Reg *ptr = method; ptr->name; ptr++) {
+        lua_pushcfunction(L, ptr->func);
+        lua_setfield(L, -2, ptr->name);
+    }
+    lua_setfield(L, -2, "__index");
+    lua_pop(L, 1);
+}

--- a/test/trigger_test.lua
+++ b/test/trigger_test.lua
@@ -1,0 +1,342 @@
+local testcase = require('testcase')
+local assert = require('assert')
+local epoll = require('epoll')
+local errno = require('errno')
+
+function testcase.type()
+    local ep = assert(epoll.new())
+    local ev = ep:new_event()
+    assert(ev:as_trigger())
+
+    -- test that get the event type
+    assert.equal(ev:type(), 'trigger')
+end
+
+function testcase.renew()
+    local ep1 = assert(epoll.new())
+    local ep2 = assert(epoll.new())
+    local ev = ep1:new_event()
+    assert(ev:as_trigger())
+
+    -- test that renew event with other epoll
+    assert(ev:renew(ep2))
+
+    -- test that throws an error if invalid argument
+    local err = assert.throws(function()
+        ev:renew('invalid')
+    end)
+    assert.match(err, 'epoll expected')
+end
+
+function testcase.revert()
+    local ep = assert(epoll.new())
+    local ev = ep:new_event()
+    assert(ev:as_trigger())
+    assert.match(ev, '^epoll%.trigger: ', false)
+
+    -- test that revert event to initial state
+    assert(ev:revert())
+    assert.match(ev, '^epoll%.event: ', false)
+end
+
+function testcase.watch_unwatch()
+    local ep = assert(epoll.new())
+    local ev = ep:new_event()
+    assert(ev:as_trigger())
+
+    -- test that return false without error if event is already watched
+    local ok, err, errnum = ev:watch()
+    assert.is_false(ok)
+    assert.is_nil(err)
+    assert.is_nil(errnum)
+
+    -- test that return true if event is unwatched
+    ok, err, errnum = ev:unwatch()
+    assert.is_true(ok)
+    assert.is_nil(err)
+    assert.is_nil(errnum)
+
+    -- test that return false without error if event is already unwatched
+    ok, err, errnum = ev:unwatch()
+    assert.is_false(ok)
+    assert.is_nil(err)
+    assert.is_nil(errnum)
+
+    -- test that return true if event will be re-watched
+    ok, err, errnum = ev:watch()
+    assert.is_true(ok)
+    assert.is_nil(err)
+    assert.is_nil(errnum)
+end
+
+function testcase.is_enabled()
+    local ep = assert(epoll.new())
+    local ev = ep:new_event()
+    assert(ev:as_trigger())
+
+    -- test that return true if event is enabled
+    assert.is_true(ev:is_enabled())
+
+    -- test that return false if event is not enabled
+    assert(ev:unwatch())
+    assert.is_false(ev:is_enabled())
+end
+
+function testcase.as_level_is_level()
+    local ep = assert(epoll.new())
+    local ev = ep:new_event()
+    assert(ev:as_trigger())
+    ev:unwatch()
+
+    -- test that remove the oneshot flags
+    assert(ev:as_oneshot())
+    assert.is_false(ev:is_level())
+    assert(ev:as_level())
+    assert.is_true(ev:is_level())
+
+    -- test that remove the edge flag
+    assert(ev:as_edge())
+    assert.is_false(ev:is_level())
+    assert(ev:as_level())
+    assert.is_true(ev:is_level())
+
+    -- test that return error if event is in-progress
+    assert(ev:watch())
+    local err, errnum
+    ev, err, errnum = ev:as_level()
+    assert.is_nil(ev)
+    assert.equal(err, errno.EINPROGRESS.message)
+    assert.equal(errnum, errno.EINPROGRESS.code)
+end
+
+function testcase.as_edge_is_edge()
+    local ep = assert(epoll.new())
+    local ev = ep:new_event()
+    assert(ev:as_trigger())
+    ev:unwatch()
+
+    -- test that set the edge flags
+    assert.is_false(ev:is_edge())
+    assert(ev:as_edge())
+    assert.is_true(ev:is_edge())
+
+    -- test that return error if event is in-progress
+    assert(ev:watch())
+    local err, errnum
+    ev, err, errnum = ev:as_edge()
+    assert.is_nil(ev)
+    assert.equal(err, errno.EINPROGRESS.message)
+    assert.equal(errnum, errno.EINPROGRESS.code)
+end
+
+function testcase.as_oneshot_is_oneshot()
+    local ep = assert(epoll.new())
+    local ev = ep:new_event()
+    assert(ev:as_trigger())
+    ev:unwatch()
+
+    -- test that set the oneshot flags
+    assert.is_false(ev:is_oneshot())
+    assert(ev:as_oneshot())
+    assert.is_true(ev:is_oneshot())
+
+    -- test that return error if event is in-progress
+    assert(ev:watch())
+    local err, errnum
+    ev, err, errnum = ev:as_oneshot()
+    assert.is_nil(ev)
+    assert.equal(err, errno.EINPROGRESS.message)
+    assert.equal(errnum, errno.EINPROGRESS.code)
+end
+
+function testcase.ident()
+    local ep = assert(epoll.new())
+    local ev = ep:new_event()
+    assert(ev:as_trigger())
+
+    -- test that return ident (eventfd, a non-negative integer)
+    local id = ev:ident()
+    assert.is_int(id)
+    assert(id >= 0)
+end
+
+function testcase.udata()
+    local ep = assert(epoll.new())
+    local ev = ep:new_event()
+    assert(ev:as_trigger(false, 'mydata'))
+
+    -- test that set udata to nil and return previous udata
+    assert.equal(ev:udata(nil), 'mydata')
+
+    -- test that return nil
+    assert.is_nil(ev:udata())
+end
+
+function testcase.getinfo()
+    local ep = assert(epoll.new())
+    local ev = ep:new_event()
+    assert(ev:as_trigger())
+
+    -- test that get info of registered event
+    assert.is_table(ev:getinfo('registered'))
+
+    -- test that get info of occurred event
+    assert.is_table(ev:getinfo('occurred'))
+
+    -- test that throws an error if invalid info name
+    local err = assert.throws(function()
+        ev:getinfo('invalid')
+    end)
+    assert.match(err, 'invalid option')
+end
+
+function testcase.trigger_counter_mode()
+    local ep = assert(epoll.new())
+    local ev = ep:new_event()
+    assert(ev:as_trigger(false, 'ctx'))
+
+    -- test that trigger fires epoll event
+    assert(ev:trigger())
+    local nevt = assert(ep:wait(0.1))
+    assert.equal(nevt, 1)
+    local oev, udata = assert(ep:consume())
+    assert.equal(oev, ev)
+    assert.equal(udata, 'ctx')
+    assert.is_false(oev:is_eof())
+
+    -- test that event does not fire after consume
+    nevt = assert(ep:wait(0))
+    assert.equal(nevt, 0)
+end
+
+function testcase.trigger_counter_mode_multiple()
+    local ep = assert(epoll.new())
+    local ev = ep:new_event()
+    assert(ev:as_trigger())
+
+    -- test that multiple triggers are coalesced into one event
+    assert(ev:trigger())
+    assert(ev:trigger())
+    assert(ev:trigger())
+    local nevt = assert(ep:wait(0.1))
+    assert.equal(nevt, 1)
+    local oev = assert(ep:consume())
+    assert.equal(oev, ev)
+
+    -- test that event does not fire after consume (all triggers consumed)
+    nevt = assert(ep:wait(0))
+    assert.equal(nevt, 0)
+end
+
+function testcase.trigger_semaphore_mode()
+    local ep = assert(epoll.new())
+    local ev = ep:new_event()
+    assert(ev:as_trigger(true))
+
+    -- test that three triggers fire three separate consume events
+    assert(ev:trigger())
+    assert(ev:trigger())
+    assert(ev:trigger())
+
+    -- first consume
+    local nevt = assert(ep:wait(0.1))
+    assert.equal(nevt, 1)
+    local oev = assert(ep:consume())
+    assert.equal(oev, ev)
+
+    -- second consume
+    nevt = assert(ep:wait(0.1))
+    assert.equal(nevt, 1)
+    oev = assert(ep:consume())
+    assert.equal(oev, ev)
+
+    -- third consume
+    nevt = assert(ep:wait(0.1))
+    assert.equal(nevt, 1)
+    oev = assert(ep:consume())
+    assert.equal(oev, ev)
+
+    -- no more events
+    nevt = assert(ep:wait(0))
+    assert.equal(nevt, 0)
+end
+
+function testcase.trigger_counter_mode_oneshot_rearm()
+    local ep = assert(epoll.new())
+    local ev = ep:new_event()
+    assert(ev:as_trigger(false))
+    assert(ev:unwatch())
+    assert(ev:as_oneshot())
+    assert(ev:watch())
+
+    -- fire the oneshot with multiple triggers
+    assert(ev:trigger())
+    assert(ev:trigger())
+    assert(ev:trigger())
+    local nevt = assert(ep:wait(0.1))
+    assert.equal(nevt, 1)
+    local oev = assert(ep:consume())
+    assert.equal(oev, ev)
+
+    -- test that re-watching does not immediately fire (eventfd must be drained on consume)
+    assert(ev:watch())
+    nevt = assert(ep:wait(0))
+    assert.equal(nevt, 0)
+
+    -- test that a subsequent trigger fires correctly after re-watch
+    assert(ev:trigger())
+    nevt = assert(ep:wait(0.1))
+    assert.equal(nevt, 1)
+    oev = assert(ep:consume())
+    assert.equal(oev, ev)
+end
+
+function testcase.trigger_semaphore_mode_oneshot_rearm()
+    local ep = assert(epoll.new())
+    local ev = ep:new_event()
+    assert(ev:as_trigger(true))
+    assert(ev:unwatch())
+    assert(ev:as_oneshot())
+    assert(ev:watch())
+
+    -- fire the oneshot with three triggers (counter=3)
+    assert(ev:trigger())
+    assert(ev:trigger())
+    assert(ev:trigger())
+    local nevt = assert(ep:wait(0.1))
+    assert.equal(nevt, 1)
+    local oev = assert(ep:consume())
+    assert.equal(oev, ev)
+
+    -- test that re-watching fires immediately because counter=2 remains
+    assert(ev:watch())
+    nevt = assert(ep:wait(0))
+    assert.equal(nevt, 1)
+    oev = assert(ep:consume())
+    assert.equal(oev, ev)
+
+    -- test that re-watching fires again because counter=1 remains
+    assert(ev:watch())
+    nevt = assert(ep:wait(0))
+    assert.equal(nevt, 1)
+    oev = assert(ep:consume())
+    assert.equal(oev, ev)
+
+    -- test that re-watching does not fire because counter=0
+    assert(ev:watch())
+    nevt = assert(ep:wait(0))
+    assert.equal(nevt, 0)
+end
+
+function testcase.trigger_returns_error_when_unwatched()
+    local ep = assert(epoll.new())
+    local ev = ep:new_event()
+    assert(ev:as_trigger())
+    assert(ev:unwatch())
+
+    -- test that trigger returns error if event is not enabled
+    local ok, err, errnum = ev:trigger()
+    assert.is_false(ok)
+    assert.equal(err, errno.EINPROGRESS.message)
+    assert.equal(errnum, errno.EINPROGRESS.code)
+end


### PR DESCRIPTION
This pull request adds support for a new "trigger" event type to the epoll Lua binding, allowing user-controlled wakeups in addition to the existing read, write, signal, and timer events. The documentation is updated to describe the new trigger event, its usage, and changes to method signatures for consistency. Several internal changes are made to support the new event type, including updates to the C code and Lua API.

**New Trigger Event Support:**

* Added a new event type, `epoll.trigger`, which allows user-controlled wakeups via `ev:trigger()`. This includes new methods `as_trigger` and `trigger`, updates to the event lifecycle, and documentation with usage examples. (`README.md`, `src/lua_epoll.h`, `src/event.c`, `src/epoll.c`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R159) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R437-R503) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R517) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R556) [[5]](diffhunk://#diff-f6c5883a603e481644b9ef028b158acace9eabf59598f164dbec7b97d8da231fL39-R40) [[6]](diffhunk://#diff-f6c5883a603e481644b9ef028b158acace9eabf59598f164dbec7b97d8da231fR150-R152) [[7]](diffhunk://#diff-f6c5883a603e481644b9ef028b158acace9eabf59598f164dbec7b97d8da231fR178-R180) [[8]](diffhunk://#diff-e9f1d0937fabed59815631e3d17e65d116f9bd2a9a1463d0a017fecd90fc3e59R56-R58) [[9]](diffhunk://#diff-e9f1d0937fabed59815631e3d17e65d116f9bd2a9a1463d0a017fecd90fc3e59R288) [[10]](diffhunk://#diff-e9f1d0937fabed59815631e3d17e65d116f9bd2a9a1463d0a017fecd90fc3e59R306) [[11]](diffhunk://#diff-e9f1d0937fabed59815631e3d17e65d116f9bd2a9a1463d0a017fecd90fc3e59R331-R332) [[12]](diffhunk://#diff-e9f1d0937fabed59815631e3d17e65d116f9bd2a9a1463d0a017fecd90fc3e59R364) [[13]](diffhunk://#diff-d7b85dd13ad37f50a9fc23e68961ebe40065e3254f15aa8d6fd4e8b9d51f0f80R98) [[14]](diffhunk://#diff-c568c1b3b94a5cc84be9965f9233c28b29cbd167a9decdbf62233241ac52ea2eR69) [[15]](diffhunk://#diff-c568c1b3b94a5cc84be9965f9233c28b29cbd167a9decdbf62233241ac52ea2eR89) [[16]](diffhunk://#diff-c568c1b3b94a5cc84be9965f9233c28b29cbd167a9decdbf62233241ac52ea2eR115-R128)

**Documentation Improvements and API Consistency:**

* Updated the documentation to reflect new and changed method signatures for `as_level`, `as_edge`, and `as_oneshot`, now returning `(ev, err, errno)` for consistency. Added detailed return value documentation and clarified behavior for all event types. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L185-R196) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L206-R218) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L226-R240) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L533-R613) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L555-R635) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L577-R657)
* Added `trigger` to the lists and descriptions of event types and updated usage examples and parameter explanations. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R517) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R556) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R699)

**Bug Fixes and Minor Corrections:**

* Fixed typos in variable names in code examples (`ocurred` → `occurred`). (`README.md`)
* Corrected timer example to use seconds instead of milliseconds. (`README.md`)
* Added missing documentation for the `eof` field in event info. (`README.md`)
* Minor cleanup and clarification in event info and documentation. (`README.md`)

**Internal Codebase Updates:**

* Updated C structures and initialization to track trigger event references, manage their lifecycle, and integrate with the event loop. (`src/lua_epoll.h`, `src/epoll.c`, `src/common.c`) [[1]](diffhunk://#diff-f6c5883a603e481644b9ef028b158acace9eabf59598f164dbec7b97d8da231fL39-R40) [[2]](diffhunk://#diff-f6c5883a603e481644b9ef028b158acace9eabf59598f164dbec7b97d8da231fR150-R152) [[3]](diffhunk://#diff-f6c5883a603e481644b9ef028b158acace9eabf59598f164dbec7b97d8da231fR178-R180) [[4]](diffhunk://#diff-e9f1d0937fabed59815631e3d17e65d116f9bd2a9a1463d0a017fecd90fc3e59R288) [[5]](diffhunk://#diff-e9f1d0937fabed59815631e3d17e65d116f9bd2a9a1463d0a017fecd90fc3e59R306) [[6]](diffhunk://#diff-e9f1d0937fabed59815631e3d17e65d116f9bd2a9a1463d0a017fecd90fc3e59R331-R332) [[7]](diffhunk://#diff-c568c1b3b94a5cc84be9965f9233c28b29cbd167a9decdbf62233241ac52ea2eR89) [[8]](diffhunk://#diff-c568c1b3b94a5cc84be9965f9233c28b29cbd167a9decdbf62233241ac52ea2eR115-R128)
* Added necessary includes and case handling for the new event type. (`src/lua_epoll.h`, `src/epoll.c`) [[1]](diffhunk://#diff-c568c1b3b94a5cc84be9965f9233c28b29cbd167a9decdbf62233241ac52ea2eR30) [[2]](diffhunk://#diff-e9f1d0937fabed59815631e3d17e65d116f9bd2a9a1463d0a017fecd90fc3e59R56-R58)

These changes collectively add a powerful new event type and improve the usability and consistency of the epoll Lua interface.